### PR TITLE
Add basic Philips Moonlight support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Please follow the instructions on [Retrieving the Access Token](https://home-ass
   - reminder
   - eyecare_mode
 
+### Philips Moonlight Bedside Lamp
+
+* Power (on, off)
+* Brightness
+* Color temperature (175...370 mireds)
+
 ## Setup
 
 ```

--- a/custom_components/light/xiaomi_miio.py
+++ b/custom_components/light/xiaomi_miio.py
@@ -1,5 +1,5 @@
 """
-Support for Xiaomi Philips Lights (LED Ball & Ceiling Lamp, Eyecare Lamp 2).
+Support for Xiaomi Philips Lights (LED Ball & Ceiling Lamp, Eyecare Lamp 2, Bedside Lamp).
 
 For more details about this platform, please refer to the documentation
 https://home-assistant.io/components/light.xiaomi_miio/
@@ -37,6 +37,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         ['philips.light.sread1',
          'philips.light.ceiling',
          'philips.light.zyceiling',
+         'philips.light.moonlight',
          'philips.light.bulb',
          'philips.light.candle',
          'philips.light.candle2',
@@ -145,7 +146,7 @@ async def async_setup_platform(hass, config, async_add_devices,
         devices.append(secondary_device)
         # The ambient light doesn't expose additional services.
         # A hass.data[DATA_KEY] entry isn't needed.
-    elif model in ['philips.light.ceiling', 'philips.light.zyceiling']:
+    elif model in ['philips.light.ceiling', 'philips.light.zyceiling', 'philips.light.moonlight']:
         from miio import Ceil
         light = Ceil(host, token)
         device = XiaomiPhilipsCeilingLamp(name, light, model, unique_id)


### PR DESCRIPTION
This pull request adds basic support for the "Xiaomi Philips Bedside Lamp".  This addresses [Issue #16 ](https://github.com/syssi/philipslight/issues/16).

The change enables that a "Xiaomi Philips Bedside Lamp" is treated like a "Philips Ceiling Lamp".  It is missing color control and other advanced features.

The change is tested with two Philips bedside lamps through home-assisstant and iOS Home.app. It is possible to control power, brightness, white color temperature.