### PR TITLE
Align required construct version with Home Assistant 2024.2

### DIFF
--- a/custom_components/xiaomi_miio_philipslight/manifest.json
+++ b/custom_components/xiaomi_miio_philipslight/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/syssi/philipslight/issues",
   "requirements": [
-    "construct==2.10.56",
+    "construct==2.10.70",
     "python-miio>=0.5.12"
   ],
   "version": "2022.8.0.0"

--- a/custom_components/xiaomi_miio_philipslight/manifest.json
+++ b/custom_components/xiaomi_miio_philipslight/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/syssi/philipslight/issues",
   "requirements": [
-    "construct==2.10.70",
+    "construct==2.10.68",
     "python-miio>=0.5.12"
   ],
   "version": "2022.8.0.0"


### PR DESCRIPTION
Integration stopped working after latest core update, this fixes it