### PR TITLE
feat: Auto-activate Scene 6 (Midnight Mode) when brightness is 1-3%

### DIFF
--- a/custom_components/xiaomi_miio_philipslight/light.py
+++ b/custom_components/xiaomi_miio_philipslight/light.py
@@ -37,6 +37,7 @@ DATA_KEY = "light.xiaomi_miio_philipslight"
 DOMAIN = "xiaomi_miio_philipslight"
 
 CONF_MODEL = "model"
+CONF_AUTO_MIDNIGHT_MODE = "auto_midnight_mode"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -58,6 +59,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
                 "philips.light.hbulb",
             ]
         ),
+        vol.Optional(CONF_AUTO_MIDNIGHT_MODE, default=True): cv.boolean,
     }
 )
 
@@ -131,6 +133,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     token = config[CONF_TOKEN]
     name = config[CONF_NAME]
     model = config.get(CONF_MODEL)
+    auto_midnight_mode = config.get(CONF_AUTO_MIDNIGHT_MODE, True)
 
     _LOGGER.info("Initializing with host %s (token %s...)", host, token[:5])
 
@@ -171,7 +174,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         hass.data[DATA_KEY][host] = device
     elif model == "philips.light.moonlight":
         light = PhilipsMoonlight(host, token)
-        device = XiaomiPhilipsMoonlightLamp(name, light, model, unique_id)
+        device = XiaomiPhilipsMoonlightLamp(name, light, model, unique_id, auto_midnight_mode)
         devices.append(device)
         hass.data[DATA_KEY][host] = device
     elif model in [
@@ -798,12 +801,13 @@ class XiaomiPhilipsMoonlightLamp(XiaomiPhilipsBulb):
 
     _attr_supported_color_modes = {ColorMode.COLOR_TEMP, ColorMode.HS}
 
-    def __init__(self, name, light, model, unique_id):
+    def __init__(self, name, light, model, unique_id, auto_midnight_mode=True):
         """Initialize the light device."""
         super().__init__(name, light, model, unique_id)
 
         self._music_mode = False
         self._hs_color = None
+        self._auto_midnight_mode = auto_midnight_mode
         self._state_attrs.pop(ATTR_DELAYED_TURN_OFF)
         self._state_attrs.update(
             {
@@ -928,7 +932,7 @@ class XiaomiPhilipsMoonlightLamp(XiaomiPhilipsBulb):
             percent_brightness = ceil(100 * brightness / 255.0)
 
             # === Auto-activate Scene 6 (Midnight Mode) when brightness is 1-3% ===
-            if percent_brightness >= 1 and percent_brightness <= 3:
+            if self._auto_midnight_mode and percent_brightness >= 1 and percent_brightness <= 3:
                 _LOGGER.info(
                     "Brightness set to %s%% for %s, automatically activating scene 6 (midnight mode)",
                     percent_brightness,

--- a/custom_components/xiaomi_miio_philipslight/light.py
+++ b/custom_components/xiaomi_miio_philipslight/light.py
@@ -133,7 +133,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     token = config[CONF_TOKEN]
     name = config[CONF_NAME]
     model = config.get(CONF_MODEL)
-    auto_midnight_mode = config.get(CONF_AUTO_MIDNIGHT_MODE, True)
+    auto_midnight_mode = config.get(CONF_AUTO_MIDNIGHT_MODE)
 
     _LOGGER.info("Initializing with host %s (token %s...)", host, token[:5])
 

--- a/custom_components/xiaomi_miio_philipslight/light.py
+++ b/custom_components/xiaomi_miio_philipslight/light.py
@@ -950,7 +950,7 @@ class XiaomiPhilipsMoonlightLamp(XiaomiPhilipsBulb):
                     self._state = True
                     self._brightness = brightness
                     self._scene = 6
-                    return  # Exit without calling set_brightness
+                    return
                 else:
                     _LOGGER.error("Failed to set scene 6 for %s, falling back to brightness", self._name)
 

--- a/custom_components/xiaomi_miio_philipslight/light.py
+++ b/custom_components/xiaomi_miio_philipslight/light.py
@@ -927,6 +927,30 @@ class XiaomiPhilipsMoonlightLamp(XiaomiPhilipsBulb):
             brightness = kwargs[ATTR_BRIGHTNESS]
             percent_brightness = ceil(100 * brightness / 255.0)
 
+            # === Auto-activate Scene 6 (Midnight Mode) when brightness is 1-3% ===
+            if percent_brightness >= 1 and percent_brightness <= 3:
+                _LOGGER.info(
+                    "Brightness set to %s%% for %s, automatically activating scene 6 (midnight mode)",
+                    percent_brightness,
+                    self._name
+                )
+
+                # Activate scene 6
+                result = await self._try_command(
+                    "Setting scene 6 failed",
+                    self._light.set_scene,
+                    6
+                )
+
+                if result:
+                    self._state = True
+                    self._brightness = brightness
+                    self._scene = 6
+                    return  # Exit without calling set_brightness
+                else:
+                    _LOGGER.error("Failed to set scene 6 for %s, falling back to brightness", self._name)
+            # === End of custom modification ===
+
             _LOGGER.debug("Setting brightness: %s %s%%", brightness, percent_brightness)
 
             result = await self._try_command(

--- a/custom_components/xiaomi_miio_philipslight/light.py
+++ b/custom_components/xiaomi_miio_philipslight/light.py
@@ -174,7 +174,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         hass.data[DATA_KEY][host] = device
     elif model == "philips.light.moonlight":
         light = PhilipsMoonlight(host, token)
-        device = XiaomiPhilipsMoonlightLamp(name, light, model, unique_id, auto_midnight_mode)
+        device = XiaomiPhilipsMoonlightLamp(
+            name, light, model, unique_id, auto_midnight_mode
+        )
         devices.append(device)
         hass.data[DATA_KEY][host] = device
     elif model in [
@@ -931,17 +933,19 @@ class XiaomiPhilipsMoonlightLamp(XiaomiPhilipsBulb):
             brightness = kwargs[ATTR_BRIGHTNESS]
             percent_brightness = ceil(100 * brightness / 255.0)
 
-            if self._auto_midnight_mode and percent_brightness >= 1 and percent_brightness <= 3:
+            if (
+                self._auto_midnight_mode
+                and percent_brightness >= 1
+                and percent_brightness <= 3
+            ):
                 _LOGGER.info(
                     "Brightness set to %s%% for %s, automatically activating scene 6 (midnight mode)",
                     percent_brightness,
-                    self._name
+                    self._name,
                 )
 
                 result = await self._try_command(
-                    "Setting scene 6 failed",
-                    self._light.set_scene,
-                    6
+                    "Setting scene 6 failed", self._light.set_scene, 6
                 )
 
                 if result:
@@ -950,7 +954,10 @@ class XiaomiPhilipsMoonlightLamp(XiaomiPhilipsBulb):
                     self._scene = 6
                     return
                 else:
-                    _LOGGER.error("Failed to set scene 6 for %s, falling back to brightness", self._name)
+                    _LOGGER.error(
+                        "Failed to set scene 6 for %s, falling back to brightness",
+                        self._name,
+                    )
 
             _LOGGER.debug("Setting brightness: %s %s%%", brightness, percent_brightness)
 

--- a/custom_components/xiaomi_miio_philipslight/light.py
+++ b/custom_components/xiaomi_miio_philipslight/light.py
@@ -938,7 +938,6 @@ class XiaomiPhilipsMoonlightLamp(XiaomiPhilipsBulb):
                     self._name
                 )
 
-                # Activate scene 6
                 result = await self._try_command(
                     "Setting scene 6 failed",
                     self._light.set_scene,

--- a/custom_components/xiaomi_miio_philipslight/light.py
+++ b/custom_components/xiaomi_miio_philipslight/light.py
@@ -953,7 +953,6 @@ class XiaomiPhilipsMoonlightLamp(XiaomiPhilipsBulb):
                     return  # Exit without calling set_brightness
                 else:
                     _LOGGER.error("Failed to set scene 6 for %s, falling back to brightness", self._name)
-            # === End of custom modification ===
 
             _LOGGER.debug("Setting brightness: %s %s%%", brightness, percent_brightness)
 

--- a/custom_components/xiaomi_miio_philipslight/light.py
+++ b/custom_components/xiaomi_miio_philipslight/light.py
@@ -801,7 +801,7 @@ class XiaomiPhilipsMoonlightLamp(XiaomiPhilipsBulb):
 
     _attr_supported_color_modes = {ColorMode.COLOR_TEMP, ColorMode.HS}
 
-    def __init__(self, name, light, model, unique_id, auto_midnight_mode=True):
+    def __init__(self, name, light, model, unique_id, auto_midnight_mode):
         """Initialize the light device."""
         super().__init__(name, light, model, unique_id)
 

--- a/custom_components/xiaomi_miio_philipslight/light.py
+++ b/custom_components/xiaomi_miio_philipslight/light.py
@@ -931,7 +931,6 @@ class XiaomiPhilipsMoonlightLamp(XiaomiPhilipsBulb):
             brightness = kwargs[ATTR_BRIGHTNESS]
             percent_brightness = ceil(100 * brightness / 255.0)
 
-            # === Auto-activate Scene 6 (Midnight Mode) when brightness is 1-3% ===
             if self._auto_midnight_mode and percent_brightness >= 1 and percent_brightness <= 3:
                 _LOGGER.info(
                     "Brightness set to %s%% for %s, automatically activating scene 6 (midnight mode)",


### PR DESCRIPTION
This adds automatic Scene 6 activation for Philips ZhiRui lamps when brightness is set to very low levels (1-3%), providing better UX for activating midnight mode via UI sliders.

- Detects brightness 1-3% and auto-switches to Scene 6
- Includes error handling and fallback
- No breaking changes
- Tested on philips.light.moonlight